### PR TITLE
change file structure

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,7 @@
 const router = require('express').Router();
 
 //import file to work with api-routes for notes (for URL 'localhost:3001/api/notes')
-const notesRouter = require('./notes.js');
+const notesRouter = require('./notes');
 
 //setup a URL 'localhost:3001/api/notes'
 router.use('/notes', notesRouter);

--- a/server.js
+++ b/server.js
@@ -3,8 +3,7 @@ const express = require('express');
 const path = require('path');
 
 // const notesData = require('./db.json');
-const api = require('./routes/index');
-const apiNotes = require('./routes/notes');
+// const api = require('./routes/index');
 
 const app = express();
 const PORT = 3001;
@@ -16,27 +15,38 @@ app.use(express.static('public'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 // Send all 'localhost:3001/api' routes to the routes folder to use the index.js
-app.use('/api', api);
-app.use('/api/notes', apiNotes);
+// app.use('/api', api);
 
 //3.routes
 // sourse: UofU bootcamp, module 11, activity 05
 // a get URL 'localhost:3001/notes' request from user will bring/display to user the notes.html file 
-app.get('/notes', (req, res) =>
-    res.sendFile(path.join(__dirname, 'public/notes.html'))
+app.get('/notes', (req, res) => {
+    res.sendFile(path.join(__dirname, 'notes.html'))
 
     // display all existing notes in the left-hand column
-
+    //renderNoteList();
     // all nav-btn are not visible
+});
 
-  );
-  // a get URL 'localhost:3001/*' request from user will bring/display to user the landing page (home-page) , which is index.html file. '*' - stands for any user input
-  app.get('*', (req, res) =>
-    res.sendFile(path.join(__dirname, './public/index.html'))
-  );
+app.get('/api/notes', (req, res) => {
+  //res.json(notesData);
+  console.log('hi!');
+  res.send('Hello World!')
+  
+});
+
+
+// a get URL 'localhost:3001/*' request from user will bring/display to user the landing page (home-page) , which is index.html file. '*' - stands for any user input
+app.get('*', (req, res) =>
+  res.sendFile(path.join(__dirname, 'index.html'))
+);
+
+  
 
 //4.listen to a port 
 app.listen(PORT, () =>
     console.log(`App listening at http://localhost:${PORT} `)
   );
+
+
   

--- a/server.js
+++ b/server.js
@@ -2,8 +2,9 @@
 const express = require('express');
 const path = require('path');
 
-const notesData = require('./db.json');
-const api = require('./routes/index.js');
+// const notesData = require('./db.json');
+const api = require('./routes/index');
+const apiNotes = require('./routes/notes');
 
 const app = express();
 const PORT = 3001;
@@ -16,17 +17,22 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 // Send all 'localhost:3001/api' routes to the routes folder to use the index.js
 app.use('/api', api);
-
+app.use('/api/notes', apiNotes);
 
 //3.routes
 // sourse: UofU bootcamp, module 11, activity 05
 // a get URL 'localhost:3001/notes' request from user will bring/display to user the notes.html file 
 app.get('/notes', (req, res) =>
     res.sendFile(path.join(__dirname, 'public/notes.html'))
+
+    // display all existing notes in the left-hand column
+
+    // all nav-btn are not visible
+
   );
-  // a get URL 'localhost:3001/*' request from user will bring/display to user the index.html file. '*' - stands for any user input
+  // a get URL 'localhost:3001/*' request from user will bring/display to user the landing page (home-page) , which is index.html file. '*' - stands for any user input
   app.get('*', (req, res) =>
-    res.sendFile(path.join(__dirname, 'public/index.html'))
+    res.sendFile(path.join(__dirname, './public/index.html'))
   );
 
 //4.listen to a port 


### PR DESCRIPTION
expected:
when user use 'http://localhost:3001/api/notes' URL then server.js refers to index.js in the routes-folder, and then to notes.js  in the routes-folder. API-routs are executed from notes.js.

now:
when user use 'http://localhost:3001/api/notes' URL then server.js refers to index.js in the routes-folder. Process stops at comand 'router.use('/notes', notesRouter);', and then do not go to notes.js  in the routes-folder. API-routs are not executed from notes.js.

TODO:
1. skip rout-folder, 
2. use server.js,
3. debug